### PR TITLE
Update compile.sh to use correct Gambit filenames

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 GAMBCLIBDIR="`gsc -e \"(display (path-expand \\\"~~lib\\\"))\"`"
-echo "bh.scm:" && gsc -link -l "$GAMBCLIBDIR/_gambcgsc" bh.scm && gsc -obj bh_.c bh.c && gsc -exe -ld-options "$GAMBCLIBDIR/libgambcgsc.a" bh_.o bh.o
+echo "bh.scm:" && gsc -link -l "$GAMBCLIBDIR/_gambitgsc" bh.scm && gsc -obj bh_.c bh.c && gsc -exe -ld-options "$GAMBCLIBDIR/libgambitgsc.a" bh_.o bh.o
 rm -f bh_.o bh_.c bh.c bh.o
 


### PR DESCRIPTION
Issue #53 After building and installing Gambit tag "v4.8.5" from source (on OS X and Linux), the requested file names are not available and calling this script throws the following error:

```bash
*** ERROR -- missing or invalid linking information for module "[Gambit Path]/_gambcgsc"
gcc: error: bh_.c: No such file or directory
gcc: fatal error: no input files
compilation terminated.
*** ERROR IN ##main -- C compilation or link failed while compiling "bh_.c"
```

Updated the file names to match what Gambit currently creates, but there may still be a remaining problem created by the trailing slash that the embedded script creates when determining the Gambit library path.
